### PR TITLE
Add `text` to `contentType` option

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2022 darthrommy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetchmaki",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A simple fetch wrapper with Typescript",
   "main": "dist/cjs/index.js",
   "types": "dist/types/index.d.ts",

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -13,8 +13,8 @@ export type Fetch = typeof fetch;
 /** query type */
 export type Query = Record<string, string>;
 
-/** available content type */
-export type ContentType = "json" | "plain" | "html" | "noContent";
+/** available content type. `plain` and `html` are deprecated. */
+export type ContentType = "json" | "plain" | "html" | "noContent" | "text";
 
 /** body type */
 export type ResponseBody = string | Json | undefined;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -43,12 +43,14 @@ const handleResBody = async (res: Response, contentType: ContentType) => {
       return await res.text();
     case "html":
       return await res.text();
+    case "text":
+      return await res.text();
     case "json":
       return await res.json();
     case "noContent":
       return;
     default:
-      throw new Error("Response body type is inacceptable");
+      throw new Error("Response body type is not supported");
   }
 };
 


### PR DESCRIPTION
simplify options. maybe other than `text`, `json` and `noContent` should be dropped.