### PR TITLE
Make `Json` type more proper

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,10 +2,13 @@
 export type FetchHeaders = Record<string, string>;
 
 /** possible JSON type */
-export type Json = Record<
-  string,
-  string | number | boolean | null | { [key: string]: Json } | Json[]
->;
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json }
+  | Json[];
 
 /** fetch type */
 export type Fetch = typeof fetch;


### PR DESCRIPTION
Inspired by auto-generated table schema with `@supabase/supabase-js` v2.
```ts
export type Json =
  | string
  | number
  | boolean
  | null
  | { [key: string]: Json }
  | Json[]
```